### PR TITLE
feat(docker): configure MySQL service with healthcheck and environmen…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,40 @@
+version: "3.9"
+
 services:
+  db:
+    image: mysql:8.0
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_DATABASE: todos
+      MYSQL_USER: todo
+      MYSQL_PASSWORD: supersecret
+      MYSQL_ROOT_PASSWORD: rootsecret
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-prootsecret"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    ports:
+      - "3307:3306"
+
   app:
     build: .
     environment:
       PORT: 3000
-      SQLITE_DB_LOCATION: /data/todo.db
+      
+      MYSQL_HOST: db
+      MYSQL_USER: todo
+      MYSQL_PASSWORD: supersecret
+      MYSQL_DB: todos
+    depends_on:
+      db:
+        condition: service_healthy
+    
     volumes:
       - todo-data:/data
     expose:
@@ -19,4 +50,5 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
 
 volumes:
+  db-data:
   todo-data:


### PR DESCRIPTION
…t variables

## Descripción
agregar un contenedor de SQL que se conecte con todo_app

## Tipo de cambio
- [x] feat (nueva funcionalidad)
- [x] fix (corrección de bug)
- [ ] docs (documentación)
- [ ] refactor (cambio interno sin afectar comportamiento)
- [ ] chore (infra, dependencias, build)
- [ ] test (tests nuevos o ajustados)

## Cómo probar
docker build -t todoapp:local .
docker run --rm -p 3000:3000 \
  -e NODE_ENV=production \
  -e SQLITE_DB_LOCATION=/data/todo.db \
  -v $(pwd)/.data:/data \
  --name todoapp \
  todoapp:local
# App en http://localhost:9000

